### PR TITLE
feat: support bf16

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-: "${MODELBIN_ROOT:=/gpu_trainee/final-project/modelbin}"
+: "${MODELBIN_ROOT:=/nfs/gpu_trainee/final-project/modelbin}"
 export MODELBIN_ROOT
 export OMP_NUM_THREADS=96
 

--- a/src/forward.cpp
+++ b/src/forward.cpp
@@ -37,7 +37,7 @@ float* forward(OssTransformerHybrid* transformer, int* tokens, const int* pos_pe
     }
 
     OssConfig* p = &transformer->config;
-    OssTransformerWeightsHalf* w = &transformer->weights;
+    OssTransformerWeightsBFloat16* w = &transformer->weights;
     OssRunState* s = &transformer->state;
 
     float* x = s->x;
@@ -96,9 +96,10 @@ float* forward(OssTransformerHybrid* transformer, int* tokens, const int* pos_pe
         }
 
         // ! QKV project
-        __half* w_qkv = w->w_qkv + 1ll * l * hidden_dim *
-                                       (head_dim * p->n_attn_heads + 2 * head_dim * p->n_kv_heads);
-        __half* b_qkv =
+        __hip_bfloat16* w_qkv =
+            w->w_qkv +
+            1ll * l * hidden_dim * (head_dim * p->n_attn_heads + 2 * head_dim * p->n_kv_heads);
+        __hip_bfloat16* b_qkv =
             w->b_qkv + 1ll * l * (head_dim * p->n_attn_heads + 2 * head_dim * p->n_kv_heads);
 
         if (g_enable_profiling) {
@@ -168,8 +169,8 @@ float* forward(OssTransformerHybrid* transformer, int* tokens, const int* pos_pe
         }
 
         // ! Output projection
-        __half* w_o = w->w_o + 1ll * l * (head_dim * p->n_attn_heads) * hidden_dim;
-        __half* b_o = w->b_o + 1ll * l * hidden_dim;
+        __hip_bfloat16* w_o = w->w_o + 1ll * l * (head_dim * p->n_attn_heads) * hidden_dim;
+        __hip_bfloat16* b_o = w->b_o + 1ll * l * hidden_dim;
 
         if (g_enable_profiling) {
             CHECK_HIP(hipEventRecord(start_section, 0));
@@ -210,8 +211,8 @@ float* forward(OssTransformerHybrid* transformer, int* tokens, const int* pos_pe
         }
 
         // ! MoE Router
-        __half* w_router = w->w_router + 1ll * l * hidden_dim * n_experts;
-        __half* b_router = w->b_router + 1ll * l * n_experts;
+        __hip_bfloat16* w_router = w->w_router + 1ll * l * hidden_dim * n_experts;
+        __hip_bfloat16* b_router = w->b_router + 1ll * l * n_experts;
 
         if (g_enable_profiling) {
             CHECK_HIP(hipEventRecord(start_section, 0));

--- a/src/getp/run.cpp
+++ b/src/getp/run.cpp
@@ -23,7 +23,7 @@ void warm_up(Transformer* transformer, Tokenizer* tokenizer, int batch_size) {
 
     transformer_oss->config.batch_size = batch_size;
 
-    copy_transformer_to_device_hybrid(transformer_oss, t_d);
+    copy_transformer_to_device(transformer_oss, t_d);
 
     size_t free_mem, total_mem;
     CHECK_HIP(hipMemGetInfo(&free_mem, &total_mem));
@@ -41,7 +41,7 @@ void warm_up(Transformer* transformer, Tokenizer* tokenizer, int batch_size) {
 void finish(Transformer* transformer, Tokenizer* tokenizer) {
     print_batch_timing_summary();
 
-    free_transformer_on_device_hybrid(t_d);
+    free_transformer_on_device(t_d);
     free(t_d);
 
     size_t free_mem, total_mem;

--- a/src/hip/BLAS.hip
+++ b/src/hip/BLAS.hip
@@ -1,6 +1,6 @@
 #pragma once
 #include <hip/hip_runtime.h>
-#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
 #include <omp.h>
 
 #define CHECK_HIP(cmd)                                                                             \

--- a/src/hip/attention.hip
+++ b/src/hip/attention.hip
@@ -111,7 +111,7 @@ __global__ void fa_reduce_kernel(
     const float* __restrict__ partial_O,     // (B,H,C,D)
     const float* __restrict__ partial_m,     // (B,H,C)
     const float* __restrict__ partial_l,     // (B,H,C)
-    const __half* __restrict__ attn_sinks_half, // (H)
+    const __hip_bfloat16* __restrict__ attn_sinks_half, // (H)
     float* __restrict__ tb_batch,            // (B,H*D)
     int head_dim, int n_chunks, int n_attn_heads
 ) {
@@ -152,7 +152,7 @@ __global__ void fa_reduce_kernel(
     }
 
     if (attn_sinks_half != nullptr) {
-        float sink_s = __half2float(attn_sinks_half[h]);
+        float sink_s = __bfloat162float(attn_sinks_half[h]);
         if (isfinite(sink_s)) {
             const float m_prev = m; const float l_prev = l;
             const float m_new  = fmaxf(m_prev, sink_s);
@@ -179,7 +179,7 @@ void fa(
     const void*  k_cache,      // base pointer
     const void*  v_cache,      // base pointer
     const float* mask,         // (T, T)
-    const __half* attn_sinks,  // (L, H) — pass attn_sinks + layer_idx*H
+    const __hip_bfloat16* attn_sinks,  // (L, H) — pass attn_sinks + layer_idx*H
     float* tb_batch,           // (B, H*D)
     int B,
     int seq_len, int head_dim, int kv_dim, int kv_mul,
@@ -198,7 +198,7 @@ void fa(
 
     int tpb = fa_pow2(head_dim); if (tpb < 64) tpb = 64; else if (tpb > 256) tpb = 256;
     size_t shmem = (size_t)head_dim * sizeof(float);
-    const __half* attn_sinks_head = (attn_sinks != nullptr) ? (attn_sinks + (long long)layer_idx * n_attn_heads) : nullptr;
+    const __hip_bfloat16* attn_sinks_head = (attn_sinks != nullptr) ? (attn_sinks + (long long)layer_idx * n_attn_heads) : nullptr;
 
     // Workspace (TODO: reuse allocator if you have one)
     float* partial_O; float* partial_m; float* partial_l;

--- a/src/hip/embed.hip
+++ b/src/hip/embed.hip
@@ -1,10 +1,10 @@
 #include "BLAS.hip"
 #include <hip/hip_runtime.h>
-#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
 
 template<int VEC>
 __global__ __launch_bounds__(256)
-void embed_kernel_vec(const __half* __restrict__ emb_table,
+void embed_kernel_vec(const __hip_bfloat16* __restrict__ emb_table,
                                         const int* __restrict__ tokens,
                                         float* __restrict__ x_batch,
                                         int batch_size, int hidden_dim)
@@ -19,25 +19,25 @@ void embed_kernel_vec(const __half* __restrict__ emb_table,
     __syncthreads();
     const int token = tok_shared;
 
-    const __half* base = emb_table + (size_t)token * hidden_dim + t0;
+    const __hip_bfloat16* base = emb_table + (size_t)token * hidden_dim + t0;
     float* out       = x_batch   + (size_t)b      * hidden_dim + t0;
 
     const int pairs = (hidden_dim - t0 >= VEC) ? (VEC >> 1) : ((hidden_dim - t0) >> 1);
 #pragma unroll VEC >> 1
     for (int i = 0; i < pairs; ++i) {
-        const __half2 h2 = reinterpret_cast<const __half2*>(base)[i];
-        const float2 f2  = __half22float2(h2);
+        const __hip_bfloat162 h2 = reinterpret_cast<const __hip_bfloat162*>(base)[i];
+        const float2 f2  = __bfloat1622float2(h2);
         reinterpret_cast<float2*>(out)[i] = f2;
     }
 
     const int done = pairs << 1;
     if (done < VEC && (t0 + done) < hidden_dim) {
-        out[done] = __half2float(base[done]);
+        out[done] = __bfloat162float(base[done]);
     }
 }
 
 __global__ __launch_bounds__(256)
-void embed_kernel_scalar(const __half* __restrict__ emb_table,
+void embed_kernel_scalar(const __hip_bfloat16* __restrict__ emb_table,
                                            const int* __restrict__ tokens,
                                            float* __restrict__ x_batch,
                                            int batch_size, int hidden_dim)
@@ -53,11 +53,11 @@ void embed_kernel_scalar(const __half* __restrict__ emb_table,
 
     const int emb_offset = token * hidden_dim + idx;
     const int out_offset = b     * hidden_dim + idx;
-    x_batch[out_offset] = __half2float(emb_table[emb_offset]);
+    x_batch[out_offset] = __bfloat162float(emb_table[emb_offset]);
 }
 
 void embed(float* x_batch,
-                     __half* emb_table,
+                     __hip_bfloat16* emb_table,
                      int* tokens,
                      int batch_size,
                      int hidden_dim)
@@ -70,7 +70,7 @@ void embed(float* x_batch,
         dim3 grid((hidden_dim / VEC + threads - 1) / threads, batch_size);
         hipLaunchKernelGGL((embed_kernel_vec<VEC>),
                            grid, block, 0, 0,
-                           (const __half*)emb_table, (const int*)tokens, x_batch,
+                           (const __hip_bfloat16*)emb_table, (const int*)tokens, x_batch,
                            batch_size, hidden_dim);
     } else if ((hidden_dim & 1) == 0) {
         constexpr int VEC = 2;
@@ -78,14 +78,14 @@ void embed(float* x_batch,
         dim3 grid((hidden_dim / VEC + threads - 1) / threads, batch_size);
         hipLaunchKernelGGL((embed_kernel_vec<VEC>),
                            grid, block, 0, 0,
-                           (const __half*)emb_table, (const int*)tokens, x_batch,
+                           (const __hip_bfloat16*)emb_table, (const int*)tokens, x_batch,
                            batch_size, hidden_dim);
     } else {
         dim3 block(threads);
         dim3 grid((hidden_dim + threads - 1) / threads, batch_size);
         hipLaunchKernelGGL(embed_kernel_scalar,
                            grid, block, 0, 0,
-                           (const __half*)emb_table, (const int*)tokens, x_batch,
+                           (const __hip_bfloat16*)emb_table, (const int*)tokens, x_batch,
                            batch_size, hidden_dim);
     }
     CHECK_HIP(hipGetLastError());

--- a/src/hip/matvec.hip
+++ b/src/hip/matvec.hip
@@ -1,12 +1,12 @@
 #include "BLAS.hip"
 #include <hip/hip_runtime.h>
-#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
 
 template <int RB, int KTILE>
-__global__ void matvec_kernel(const __half* __restrict__ A_half,
+__global__ void matvec_kernel(const __hip_bfloat16* __restrict__ A_half,
                                           const float* __restrict__ B_batch,
                                           float* __restrict__ C_batch,
-                                          const __half* __restrict__ bias,
+                                          const __hip_bfloat16* __restrict__ bias,
                                           int batch_size, int M, int K) {
     const int lane = threadIdx.x;
     const int warp = threadIdx.y;
@@ -43,10 +43,10 @@ __global__ void matvec_kernel(const __half* __restrict__ A_half,
         for (int j4 = lane; j4 < vecRow; j4 += warpSize) {
             const int j = j4 << 2;
 
-            half2 a0 = *reinterpret_cast<const half2*>(&A_half[a_base + k0 + j + 0]);
-            half2 a1 = *reinterpret_cast<const half2*>(&A_half[a_base + k0 + j + 2]);
-            float2 af0 = __half22float2(a0);
-            float2 af1 = __half22float2(a1);
+            __hip_bfloat162 a0 = *reinterpret_cast<const __hip_bfloat162*>(&A_half[a_base + k0 + j + 0]);
+            __hip_bfloat162 a1 = *reinterpret_cast<const __hip_bfloat162*>(&A_half[a_base + k0 + j + 2]);
+            float2 af0 = __bfloat1622float2(a0);
+            float2 af1 = __bfloat1622float2(a1);
             float4 bv = *reinterpret_cast<const float4*>(&sB[j]);
 
             acc = fmaf(af0.x, bv.x, acc);
@@ -56,7 +56,7 @@ __global__ void matvec_kernel(const __half* __restrict__ A_half,
         }
         for (int j = (vecRow << 2) + lane; j < Ktile; j += warpSize) {
             float b = sB[j];
-            float a = __half2float(A_half[a_base + k0 + j]);
+            float a = __bfloat162float(A_half[a_base + k0 + j]);
             acc = fmaf(a, b, acc);
         }
         __syncthreads();
@@ -65,14 +65,14 @@ __global__ void matvec_kernel(const __half* __restrict__ A_half,
     acc = warp_reduce_sum_64(acc);
 
     if (lane == 0) {
-        float badd = bias ? __half2float(bias[row]) : 0.0f;
+        float badd = bias ? __bfloat162float(bias[row]) : 0.0f;
         C[row] = acc + badd;
     }
 }
 
 static inline int ceil_div(int a, int b) { return (a + b - 1) / b; }
 
-void matvec(float* xout, float* x_batch, __half* w, __half* bias,
+void matvec(float* xout, float* x_batch, __hip_bfloat16* w, __hip_bfloat16* bias,
                       int batch_size, int K /*d*/, int M /*n*/) {
     constexpr int RB    = 8;     // rows per block
     constexpr int KTILE = 2048;  // K tile

--- a/src/hip/moe.hip
+++ b/src/hip/moe.hip
@@ -1,6 +1,6 @@
 #pragma once
 #include <hip/hip_runtime.h>
-#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
 
 // ! Multi-expert MatVec
 template <int RB, int KTILE>
@@ -9,8 +9,8 @@ __global__ void moe_matvec_kernel(
     int work_start, int work_count,       // slice (per stream)
     const float* __restrict__ x_by_expert,// [sum Ne, K]
     float* __restrict__ out_by_expert,    // [sum Ne, M]
-    const __half* __restrict__ weights_base, // expert 0 base
-    const __half* __restrict__ bias_base,    // expert 0 base (nullable)
+    const __hip_bfloat16* __restrict__ weights_base, // expert 0 base
+    const __hip_bfloat16* __restrict__ bias_base,    // expert 0 base (nullable)
     int K, int M,
     long long expert_weight_stride,
     long long expert_bias_stride)
@@ -23,8 +23,8 @@ __global__ void moe_matvec_kernel(
     const int off = work_queue[q + 1];
     const int Ne  = work_queue[q + 2];
 
-    const __half* __restrict__ A_half = weights_base + (long long)e * expert_weight_stride;
-    const __half* __restrict__ bias   = bias_base ? (bias_base + (long long)e * expert_bias_stride) : nullptr;
+    const __hip_bfloat16* __restrict__ A_half = weights_base + (long long)e * expert_weight_stride;
+    const __hip_bfloat16* __restrict__ bias   = bias_base ? (bias_base + (long long)e * expert_bias_stride) : nullptr;
 
     const float* __restrict__ B_batch = x_by_expert + (long long)off * K;
     float*       __restrict__ C_batch = out_by_expert + (long long)off * M;
@@ -65,10 +65,10 @@ __global__ void moe_matvec_kernel(
         for (int j4 = lane; j4 < vecRow; j4 += 64) {
             const int j = j4 << 2;
 
-            half2 a0 = *reinterpret_cast<const half2*>(&A_half[a_base + k0 + j + 0]);
-            half2 a1 = *reinterpret_cast<const half2*>(&A_half[a_base + k0 + j + 2]);
-            float2 af0 = __half22float2(a0);
-            float2 af1 = __half22float2(a1);
+            __hip_bfloat162 a0 = *reinterpret_cast<const __hip_bfloat162*>(&A_half[a_base + k0 + j + 0]);
+            __hip_bfloat162 a1 = *reinterpret_cast<const __hip_bfloat162*>(&A_half[a_base + k0 + j + 2]);
+            float2 af0 = __bfloat1622float2(a0);
+            float2 af1 = __bfloat1622float2(a1);
 
             float4 bv = *reinterpret_cast<const float4*>(&sB[j]);
             acc = fmaf(af0.x, bv.x, acc);
@@ -78,7 +78,7 @@ __global__ void moe_matvec_kernel(
         }
         for (int j = (vecRow << 2) + lane; j < Ktile; j += 64) {
             const float b = sB[j];
-            const float a = __half2float(A_half[a_base + k0 + j]);
+            const float a = __bfloat162float(A_half[a_base + k0 + j]);
             acc = fmaf(a, b, acc);
         }
         __syncthreads();
@@ -87,7 +87,7 @@ __global__ void moe_matvec_kernel(
     acc = warp_reduce_sum_64(acc);
 
     if (lane == 0) {
-        float badd = bias ? __half2float(bias[row]) : 0.0f;
+        float badd = bias ? __bfloat162float(bias[row]) : 0.0f;
         C[row] = acc + badd;
     }
 }
@@ -95,7 +95,7 @@ __global__ void moe_matvec_kernel(
 inline void moe_matvec(
     const int* work_queue, int work_start, int work_count,
     const float* x_by_expert, float* out_by_expert,
-    const __half* weights_base, const __half* bias_base,
+    const __hip_bfloat16* weights_base, const __hip_bfloat16* bias_base,
     int K, int M, long long expert_weight_stride, long long expert_bias_stride,
     int maxNe, hipStream_t stream)
 {

--- a/src/hip/rmsnorm.hip
+++ b/src/hip/rmsnorm.hip
@@ -1,6 +1,6 @@
 #include "BLAS.hip"
 
-__global__ void rmsnorm_kernel(float* o_batch, float* x_batch, __half* weight_half,
+__global__ void rmsnorm_kernel(float* o_batch, float* x_batch, __hip_bfloat16* weight_half,
                                      int batch_size, int size) {
     int b = blockIdx.x;
     int lx = threadIdx.x;
@@ -32,11 +32,11 @@ __global__ void rmsnorm_kernel(float* o_batch, float* x_batch, __half* weight_ha
 
     ss_float = total_sum;
     for (int i = lx; i < size; i += blockDim.x) {
-        o[i] = __half2float(weight_half[i]) * ss_float * x[i];
+        o[i] = __bfloat162float(weight_half[i]) * ss_float * x[i];
     }
 }
 
-void rmsnorm(float* o_batch, float* x_batch, __half* weight, int batch_size, int size) {
+void rmsnorm(float* o_batch, float* x_batch, __hip_bfloat16* weight, int batch_size, int size) {
     dim3 blockDim(1024);
     dim3 gridDim(batch_size);
     hipLaunchKernelGGL(rmsnorm_kernel, gridDim, blockDim, 0, 0, o_batch, x_batch, weight, batch_size, size);


### PR DESCRIPTION
This pull request updates the codebase to use bfloat16 (`__hip_bfloat16`) instead of half-precision float (`__half`) for all GPU tensor weights and related operations. This change affects the model definition, device memory management, and all HIP kernel code, ensuring consistency in data types and improving compatibility with bfloat16-optimized hardware. It also updates the model binary path in the run script.

**Migration to bfloat16 precision:**

* All model weight pointers in `OssTransformerWeightsHalf` have been converted from `__half*` to `__hip_bfloat16*`, and the struct has been renamed to `OssTransformerWeightsBFloat16`. All related function signatures and variable declarations have also been updated accordingly in `include/model.hpp`, `src/forward.cpp`, and `src/getp/run.cpp`. [[1]](diffhunk://#diff-bbb9685eece2c54fbe52e4b7864f7e2b05e581efbf00e79156f223773d541fceL5-R5) [[2]](diffhunk://#diff-bbb9685eece2c54fbe52e4b7864f7e2b05e581efbf00e79156f223773d541fceL97-L140) [[3]](diffhunk://#diff-bbb9685eece2c54fbe52e4b7864f7e2b05e581efbf00e79156f223773d541fceL199-R203) [[4]](diffhunk://#diff-111eb2d30974a8f27e8ef00d107509a60ceea9d772385e0cbe997277de84c207L40-R40) [[5]](diffhunk://#diff-111eb2d30974a8f27e8ef00d107509a60ceea9d772385e0cbe997277de84c207L99-R102) [[6]](diffhunk://#diff-111eb2d30974a8f27e8ef00d107509a60ceea9d772385e0cbe997277de84c207L171-R173) [[7]](diffhunk://#diff-111eb2d30974a8f27e8ef00d107509a60ceea9d772385e0cbe997277de84c207L213-R215) [[8]](diffhunk://#diff-d2d2b2ea086e7f7f7bf8c3a0cb35446e614cfb77937b37935f5bc543a9070aedL26-R26) [[9]](diffhunk://#diff-d2d2b2ea086e7f7f7bf8c3a0cb35446e614cfb77937b37935f5bc543a9070aedL44-R44)

* All HIP kernel files now use `#include <hip/hip_bf16.h>` instead of `hip_fp16.h`, and all kernel arguments and internal variables that previously used `__half` are now `__hip_bfloat16`. All conversion intrinsics have been updated from `__half2float` to `__bfloat162float`, and similar for vectorized types. This affects `src/hip/BLAS.hip`, `src/hip/embed.hip`, `src/hip/matvec.hip`, `src/hip/moe.hip`, and `src/hip/attention.hip`. [[1]](diffhunk://#diff-ab4ef4c27507834c5b5f7796cc7476ce5e7a2050b3bf471b1d4bb4a65b71f56dL3-R3) [[2]](diffhunk://#diff-2ca75805571e07445e4e475837bf6a75490cdd9a0bd4fd5cd1c6b8c1e2bb67b3L3-R7) [[3]](diffhunk://#diff-2ca75805571e07445e4e475837bf6a75490cdd9a0bd4fd5cd1c6b8c1e2bb67b3L22-R40) [[4]](diffhunk://#diff-2ca75805571e07445e4e475837bf6a75490cdd9a0bd4fd5cd1c6b8c1e2bb67b3L56-R60) [[5]](diffhunk://#diff-2ca75805571e07445e4e475837bf6a75490cdd9a0bd4fd5cd1c6b8c1e2bb67b3L73-R88) [[6]](diffhunk://#diff-06ccede71cb4620d04f448af37e69768c868c77f819ede9f1e33b5c4f9e28671L3-R9) [[7]](diffhunk://#diff-06ccede71cb4620d04f448af37e69768c868c77f819ede9f1e33b5c4f9e28671L46-R49) [[8]](diffhunk://#diff-06ccede71cb4620d04f448af37e69768c868c77f819ede9f1e33b5c4f9e28671L59-R59) [[9]](diffhunk://#diff-06ccede71cb4620d04f448af37e69768c868c77f819ede9f1e33b5c4f9e28671L68-R75) [[10]](diffhunk://#diff-5165530ba2701bb7723d65376f3a967c0b4917be78c4baf457d6d2a8071a5b4aL114-R114) [[11]](diffhunk://#diff-5165530ba2701bb7723d65376f3a967c0b4917be78c4baf457d6d2a8071a5b4aL155-R155) [[12]](diffhunk://#diff-5165530ba2701bb7723d65376f3a967c0b4917be78c4baf457d6d2a8071a5b4aL182-R182) [[13]](diffhunk://#diff-5165530ba2701bb7723d65376f3a967c0b4917be78c4baf457d6d2a8071a5b4aL201-R201) [[14]](diffhunk://#diff-ee8164611d7401ce031c2f4d8977dc75816d3d98be5d94036926b951ffd07723L3-R3)

These changes ensure the codebase is fully transitioned to `bfloat16` precision for model weights and GPU computation, which can provide better performance and numerical stability on modern hardware.