### PR TITLE
hotfix: overlaunch `argmax`

### DIFF
--- a/src/hip/sampling.hip
+++ b/src/hip/sampling.hip
@@ -38,6 +38,48 @@ __global__ void argmax_kernel(float* logits, int vocab_size, int* result) {
     }
 }
 
+// Batched argmax kernel - one block per sequence
+__global__ void argmax_batched_kernel(const float* __restrict__ logits,
+                                      int vocab_size, int stride,
+                                      const int* __restrict__ rows,
+                                      int* __restrict__ out) {
+    int seq = blockIdx.x;
+    int tid = threadIdx.x;
+
+    int row = rows ? rows[seq] : seq;
+    int base = row * stride;
+
+    __shared__ float svals[1024];
+    __shared__ int sidx[1024];
+
+    float max_val = -INFINITY;
+    int max_idx = 0;
+
+    // Strided scan of this row
+    for (int i = tid; i < vocab_size; i += blockDim.x) {
+        float v = logits[base + i];
+        if (v > max_val) {
+            max_val = v;
+            max_idx = i;
+        }
+    }
+    svals[tid] = max_val;
+    sidx[tid] = max_idx;
+    __syncthreads();
+
+    // Block-wide reduction
+    for (int step = blockDim.x >> 1; step > 0; step >>= 1) {
+        if (tid < step) {
+            if (svals[tid] < svals[tid + step]) {
+                svals[tid] = svals[tid + step];
+                sidx[tid] = sidx[tid + step];
+            }
+        }
+        __syncthreads();
+    }
+    if (tid == 0) out[seq] = sidx[0];
+}
+
 __device__ unsigned int gpu_xorshift(unsigned long long* state) {
     *state ^= *state >> 12;
     *state ^= *state << 25;
@@ -79,6 +121,16 @@ void sample_argmax(float* logits, int vocab_size, int* result_d) {
     dim3 block(1024);
     dim3 grid(1);
     hipLaunchKernelGGL(argmax_kernel, grid, block, 0, 0, logits, vocab_size, result_d);
+    CHECK_HIP(hipGetLastError());
+}
+
+void sample_argmax_batched(const float* logits, int vocab_size,
+                           const int* rows_d, int batch,
+                           int* results_d, hipStream_t stream) {
+    dim3 block(512);
+    dim3 grid(batch);
+    hipLaunchKernelGGL(argmax_batched_kernel, grid, block, 0, stream,
+                       logits, vocab_size, vocab_size, rows_d, results_d);
     CHECK_HIP(hipGetLastError());
 }
 


### PR DESCRIPTION
# EXP (`bs`=2000)

* https://github.com/tuanlda78202/gpt-oss-hip/commit/14cdeafa581a460a4929e7f870b4b40b6b3eae23: 2913
* **FIX**: 3934

# Analysis

<img width="2048" height="1280" alt="image" src="https://github.com/user-attachments/assets/f912539c-49a1-4993-8288-88a0c8c55c89" />
<img width="2048" height="687" alt="image" src="https://github.com/user-attachments/assets/be635c72-e84c-48c2-853b-185f9f5f33cf" />


In `run.cpp::generate()` you launch one tiny kernel per active sequence on the legacy default stream (0) and then call hipStreamSynchronize(0) every step. That’s why you see ~874k launches — roughly “number of active sequences × number of decode steps”. Each launch is grid=1, block=1024, so they all serialize on stream 0; the ~85µs/launch amortized over ~875k invocations adds up to minutes.

Where the serialization comes from

In the async path (temperature==0) you do:

```
for (int s = 0; s < pending_samples; ++s) {
    float* seq_logits = batch_logits + sample_slots[s] * vocab_size;
    sample_argmax(seq_logits, vocab_size, sample_results_d + s); // stream 0
}
CHECK_HIP(hipMemcpyAsync(sample_results_h, sample_results_d, pending_samples*sizeof(int), hipMemcpyDeviceToHost, 0));
CHECK_HIP(hipStreamSynchronize(0));
```

`sample_argmax` launches `argmax_kernel` <<<1,1024,0,0>>>, i.e. one block per sequence on stream 0.

The default/legacy stream has global synchronization semantics with other work; and you then explicitly hipStreamSynchronize(0) each decode step. 
* Net effect: fully serialized, tiny kernels.